### PR TITLE
Add new index key generation code using CBOR

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/RangerMauve/hyperbeedeebee#readme",
   "dependencies": {
-    "bson": "^4.3.0"
+    "bson": "^4.3.0",
+    "cbor": "^8.1.0"
   },
   "devDependencies": {
     "hyperbee": "^1.5.4",

--- a/test.js
+++ b/test.js
@@ -272,13 +272,14 @@ test('Sort by index', async (t) => {
   try {
     await db.collection('example').createIndex(['createdAt'])
 
-    await db.collection('example').insert({ example: 1, createdAt: new Date() })
-    await db.collection('example').insert({ example: 2, createdAt: new Date() })
-    await db.collection('example').insert({ example: 3, createdAt: new Date() })
+    await db.collection('example').insert({ example: 1, createdAt: new Date(1000) })
+    await db.collection('example').insert({ example: 2, createdAt: new Date(2000) })
+    await db.collection('example').insert({ example: 3, createdAt: new Date(3000) })
 
     let counter = 3
-    for await (const { example } of db.collection('example').find().sort('createdAt', -1)) {
+    for await (const { example, createdAt } of db.collection('example').find().sort('createdAt', -1)) {
       t.equal(example, counter, 'Got doc in expected order')
+      t.equal(createdAt.getTime(), counter * 1000, 'Got expected timestamp')
       counter--
     }
 
@@ -385,6 +386,7 @@ test('Use $eq for indexes', async (t) => {
 
 test('Arrays get flattened for indexes', async (t) => {
   const db = new DB(getBee())
+
   try {
     await db.collection('example').createIndex(['ingredients', 'name'])
 


### PR DESCRIPTION
Fixes #6 

Added a new `index version v2.0` type which uses [CBOR](https://www.rfc-editor.org/rfc/rfc8949.html) to generate index keys.

Had to do some funky stuff to make sure the key prefix is correct for `$eq` and `$gt` queries since cbor does length prefixing for it's lists (not sure why that wasn't an issue for BSON 🤔)