### PR TITLE
Update holepunch libraries to fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "cbor": "^8.1.0"
   },
   "devDependencies": {
-    "hyperbee": "^1.5.4",
-    "hypercore": "^9.9.1",
-    "random-access-memory": "^3.1.2",
+    "hyperbee": "^2.4.2",
+    "hypercore": "^10.7.0",
+    "random-access-memory": "^6.1.0",
     "standard": "^16.0.3",
     "tape": "^5.2.2"
   }


### PR DESCRIPTION
This is the minimal amount of changes needed to make the tests pass.

Currently running `yarn install` and `yarn test` result in broken tests. (Also tested with npm.)  I would also have included the yarn.lock file, but I noticed in a different PR that you didn't want that file committed.  (I am interested in your reasoning because I think it might prevent this problem in the future.) 🤷 😄  

## Before:

![Screenshot 2023-02-20 at 2 05 55 PM](https://user-images.githubusercontent.com/220893/220184048-bbdebc01-c8cf-45f8-8342-f8b85fe02d29.png)


## After:

![Screenshot 2023-02-20 at 2 07 07 PM](https://user-images.githubusercontent.com/220893/220184080-693c8b4e-42da-42c4-b38c-5fe85040cacb.png)

